### PR TITLE
wrong command in usage

### DIFF
--- a/src/imgcat.c
+++ b/src/imgcat.c
@@ -300,7 +300,7 @@ static void usage(FILE *dest) {
     const int field_width = strlen(program_name);
     fprintf(dest, "Usage:\n");
     fprintf(dest,
-            "\t%s"  " [--width=<columns> --height=<rows>|--no-rescale]\n"
+            "\t%s"  " [--width=<columns> --height=<rows>|--no-resize]\n"
             "\t%*c" " [--half-height] [--depth=(8|256|iterm2)] IMAGE\n",
             program_name, field_width, ' ');
     fprintf(dest, "\t"


### PR DESCRIPTION
The usage (or `--help`) shows a `--no-rescale` option that doesn't exist. The real option is `--no-resize`.