### PR TITLE
Link against curses; necessary for compiling on arch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ MANDIR = $(PREFIX)/share/man/man1
 include config.mk
 
 # CImg requires pthread, for some reason
-LDLIBS = $(LIBS) -ltermcap -lm -lpthread
+LDLIBS = $(LIBS) -ltermcap -lm -lpthread -lcurses
 
 # Get the source files.
 SOURCES = $(wildcard src/*.c) $(wildcard src/*.cc)


### PR DESCRIPTION
➜  imgcat git:(master) make
gcc -std=c1x -Wall -Werror   -c -MMD -MP -o src/imgcat.o src/imgcat.c
gcc -std=c1x -Wall -Werror   -c -MMD -MP -o src/print_image.o src/print_image.c
gcc -std=c1x -Wall -Werror   -c -MMD -MP -o src/rgbtree.o src/rgbtree.c
g++ -std=c++0x -Wall -Werror -Wno-char-subscripts  -I./CImg   -c -MMD -MP -o src/load_image.o src/load_image.cc
g++  src/imgcat.o src/print_image.o src/rgbtree.o src/load_image.o  -ljpeg -lpng  -ltermcap -lm -lpthread -o imgcat
/usr/bin/ld: src/imgcat.o: in function `get_terminal_colours':
imgcat.c:(.text+0x244): undefined reference to `tigetnum'
collect2: error: ld returned 1 exit status
make: *** [Makefile:53: imgcat] Error 1


Linking against curses fixes this