### PR TITLE
Use autoconf to check for ncurses

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Build
 
 ### Requirements
 
-- libncurses5-dev (if `make` complains about missing `term.h`, then you don't have it)
+- libncurses5-dev
 
 (You most likely already have both of these).
 

--- a/configure.ac
+++ b/configure.ac
@@ -39,6 +39,9 @@ AC_SEARCH_LIBS([png_create_info_struct], [png],
 AC_SEARCH_LIBS([jpeg_set_defaults], [jpeg],
                [AC_DEFINE(cimg_use_jpeg)])
 
+# Try to link with ncurses:
+AC_CHECK_LIB(ncurses,[main], [], [AC_MSG_ERROR(ncurses development library required)])
+
 # Checks for header files.
 AC_CHECK_HEADERS([sys/ioctl.h sys/time.h term.h sysexits.h])
 


### PR DESCRIPTION
I noticed that the README stated that 'make' might complain about missing 'term.h' if the ncrses development libraries are not installed. I modified configure.ac to do this check using the './configure' check instead, and modified README accordingly.