### PR TITLE
Add support for true (24bit) color

### DIFF
--- a/src/print_image.h
+++ b/src/print_image.h
@@ -31,7 +31,7 @@ enum {
 
 /* The output color depth/format. */
 typedef enum {
-    F_8_COLOR, F_256_COLOR, F_ITERM2, F_UNSET
+    F_8_COLOR, F_256_COLOR, F_TRUE_COLOR, F_ITERM2, F_UNSET
 } Format;
 
 /**


### PR DESCRIPTION
Fixes issue #24. Some sample images:

*256 colors*
![sleep_256_color](https://user-images.githubusercontent.com/16228680/97701442-5309a880-1aa5-11eb-9411-47b5b13e1492.png)

*True color*
![sleep_true_color](https://user-images.githubusercontent.com/16228680/97701455-5b61e380-1aa5-11eb-9ab0-1bd94bd29658.png)
