### PR TITLE
Remove deprecated termcap and use ncurses only

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ OUTPUT_OPTION = -MMD -MP -o $@
 LD = $(CXX)
 
 # CImg requires pthread, for some reason
-LDLIBS = $(LIBS) -ltermcap -lm -lpthread
+LDLIBS = $(LIBS) -lncurses -lm -lpthread
 
 # Get the source files.
 SOURCES = $(wildcard src/*.c) $(wildcard src/*.cc)


### PR DESCRIPTION
Imgcat fails building on some linux systems due to termcap being deprecated. Ncurses seems to cover all the functions of termcap and the build suceeds. Fixed the makefile for linking. Fixes issue #57 